### PR TITLE
Correct features to compare correlation

### DIFF
--- a/1.1_Explainability.ipynb
+++ b/1.1_Explainability.ipynb
@@ -361,7 +361,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Exercise 5**: What is the correlation coefficient for the mean and median normalised acceleration? Do you think both features need to be extracted for an efficient model? "
+    "**Exercise 5**: What is the correlation coefficient for the mean acceleration in the x and y axis (xmean and ymean)? Do you think both of these features need to be extracted for an efficient model? "
    ]
   },
   {


### PR DESCRIPTION
Initially I posed an exercise to find the correlation coefficient of mean and median. 
However, median is not extracted in the default feature extraction method in notebook 1_Baseline. 
I have therefore changed this to xmean and ymean.