### PR TITLE
Update environment.yml for SSL and BMRC practical

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -144,6 +144,7 @@ dependencies:
   - tornado=6.1
   - tqdm=4.64.0
   - traitlets=5.1.1
+  - transforms3d=0.4.1
   - typing-extensions=4.1.1
   - typing_extensions=4.1.1
   - tzdata=2022a
@@ -156,4 +157,6 @@ dependencies:
   - zipp=3.8.0
   - zlib=1.2.12
   - zstd=1.5.2
+  - pip:
+    - actipy==1.1.0
 prefix:


### PR DESCRIPTION
- add `actipy`
- add `transforms3d`

Tested the env file on the CDT VM and BMRC rescomp.

Added actipy as a pip dependency because conda solver failed with `conda install -c oxwear actipy` . All pip dependencies are already satisfied by the conda environment, except for `JPype1-1.4.1` which is only used by actipy. So it shouldn't cause any dependency issues.